### PR TITLE
Align PolicyException and move to giantswarm namespace

### DIFF
--- a/helm/trivy/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy/templates/kyverno-policy-exception.yaml
@@ -4,11 +4,9 @@ apiVersion: kyverno.io/v2alpha1
 kind: PolicyException
 metadata:
   name: {{ include "trivy.fullname" . }}-exception
-  {{- if .Values.kyvernoPolicyExceptions.namespace }}
-  namespace: {{ .Values.kyvernoPolicyExceptions.namespace }}
-  {{- else }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
+  namespace: {{ .Values.kyvernoPolicyExceptions.namespace | default .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
 spec:
   exceptions:
   - policyName: disallow-capabilities-strict

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -13,7 +13,7 @@ verticalPodAutoscaler:
 # Enable Kyverno PolicyException
 kyvernoPolicyExceptions:
   enabled: true
-  namespace: ""
+  namespace: giantswarm
 
 trivy:
   rbac:


### PR DESCRIPTION
Move PolicyException to `giantswarm` and align with other PolEx.

No changelog update since this was not released yet.