### PR TITLE
correct DNS port in network policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Correct DNS port in network policies.
+
 ## [0.8.1] - 2023-05-09
 
 ### Added

--- a/helm/trivy/templates/ciliumnetworkpolicy.yaml
+++ b/helm/trivy/templates/ciliumnetworkpolicy.yaml
@@ -18,7 +18,7 @@ spec:
         - cluster
       toPorts:
         - ports:
-            - port: "53"
+            - port: "1053"
   ingress:
     - fromEntities:
         - cluster

--- a/helm/trivy/templates/network-policy.yaml
+++ b/helm/trivy/templates/network-policy.yaml
@@ -24,7 +24,7 @@ spec:
           #   - 192.168.0.0/16
     # Allow DNS.
     - ports:
-        - port: 53
+        - port: 1053
           protocol: UDP
       to:
         - namespaceSelector: {}


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/27838

coredns exposes port 1053 so we need to allow traffic to 1053. without this PR, trivy fails to start as it can't lookup ghcr.io in order to download the vulnerability DB.

### Checklist

- [x] Update changelog in CHANGELOG.md.
