### PR TITLE
Narrow egress rule down targeting DNS service only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Narrow down CiliumNetworkPolicy egress rule to match DNS service only.
+- Narrow down CiliumNetworkPolicy ingress rule to match `trivy-operator` only.
 
 ## [0.13.1] - 2024-11-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Narrow down CiliumNetworkPolicy egress rule to match DNS service only.
-- Narrow down CiliumNetworkPolicy ingress rule to match `trivy-operator` only.
+- Narrow down CiliumNetworkPolicy ingress rule to allow traffic from namespace.
 
 ## [0.13.1] - 2024-11-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Narrow down CiliumNetworkPolicy egress rule to match DNS service only.
+
 ## [0.13.1] - 2024-11-05
 
 ### Changed

--- a/helm/trivy/templates/ciliumnetworkpolicy.yaml
+++ b/helm/trivy/templates/ciliumnetworkpolicy.yaml
@@ -14,8 +14,13 @@ spec:
   egress:
     - toEntities:
         - world
-    - toEntities:
-        - cluster
+    - toEndpoints:
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: coredns
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: k8s-dns-node-cache
       toPorts:
         - ports:
             - port: "1053"

--- a/helm/trivy/templates/ciliumnetworkpolicy.yaml
+++ b/helm/trivy/templates/ciliumnetworkpolicy.yaml
@@ -28,7 +28,7 @@ spec:
   ingress:
     - fromEndpoints:
       - matchLabels:
-          vulnerabilityreport.scanner: Trivy
+          io.kubernetes.pod.namespace: {{ .Release.Namespace }}
       toPorts:
         - ports:
             - port: "{{ .Values.trivy.service.port | default 4954 }}"

--- a/helm/trivy/templates/ciliumnetworkpolicy.yaml
+++ b/helm/trivy/templates/ciliumnetworkpolicy.yaml
@@ -26,8 +26,9 @@ spec:
             - port: "1053"
             - port: "53"
   ingress:
-    - fromEntities:
-        - cluster
+    - fromEndpoints:
+      - matchLabels:
+          vulnerabilityreport.scanner: Trivy
       toPorts:
         - ports:
             - port: "{{ .Values.trivy.service.port | default 4954 }}"


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

Having both egress and ingress targeting entire cluster is causing issues to schedule the trivy pod on big clusters. This is because the policy is big enough to fill the BPF map up.

In the egress case, I understand that you are only meant to target the DNS service; so narrowing it down to only the DNS service pods labels makes sense to me.

On the ingress side, I'm not sure what is the real traffic that comes in.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

**Important:** After this PR is tested and approved, ensure you "Squash and Merge" _unless you are updating a subtree_. The release automation in use on this repository relies on squashing, but git subtrees will be lost if squashed. This repo allows both, so you may need to change the merge type when merging.
