### PR TITLE
chore: drop inline vendir customManager

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,17 +5,6 @@
     'github>giantswarm/renovate-presets:disable-vendir.json5',
     'github>giantswarm/renovate-presets:disable-upstream-charts.json5',
   ],
-  customManagers: [
-    {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/(^|/)vendir\\.yml$/',
-      ],
-      matchStrings: [
-        '# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\n]+)\\n\\s+ref: (?<currentValue>[^\\n]+)',
-      ],
-    },
-  ],
   packageRules: [
     {
       matchFileNames: [


### PR DESCRIPTION
The vendir `customManager` and its matching `packageRule` (`branchPrefix`, `prCreation`) are now provided by `giantswarm/renovate-presets:default.json5` (renovate-presets#99). The inline copy is a duplicate once that PR lands.

The repo-specific `groupName: trivy-upstream` and `separateMajorMinor: false` are kept in the vendir `packageRule`.

Merge after renovate-presets#99.