### PR TITLE
chore(renovate): remove redundant architect automerge rule

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -26,16 +26,5 @@
       groupName: 'trivy-upstream',
       separateMajorMinor: false,
     },
-    {
-      description: 'Automerge architect updates',
-      matchFileNames: [
-        '.circleci/config.yml',
-      ],
-      matchDepNames: [
-        'architect',
-      ],
-      groupName: 'Architect',
-      automerge: true,
-    },
   ],
 }


### PR DESCRIPTION
The \`giantswarm/renovate-presets:default.json5\` preset already automerges architect-orb patch and minor updates. The inline rule had no \`matchUpdateTypes\` constraint, making it implicitly automerge major updates too.

Removing the block restores the intended fleet-wide policy: patch and minor automerge via the preset, majors require manual approval.